### PR TITLE
feat: Add a `binder` link for easy access to materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/UOMDSS/workshops-2022-2023/HEAD)
+
 # UOMDSS Workshop Materials
 
 This repository contains slides, codes, datasets, and all materials for workshops of [*Manchester University’s Data Science Society*](https://uomdss.co.uk/).


### PR DESCRIPTION
[Binder](https://mybinder.org/) is a free tool which allows for custom computing environments that can be shared and used by many remote users. I think these could be ideal for our workshops. Instead of going through the troubles of opening Colab or creating environments on laptops, attendees can just click on the link and connect on a free cloud environment running jupyterlab. 

For more advanced presentations with the need for more compute we can switch to Colab but I think for simpler projects such as EDA or Clustering we can use binder.

